### PR TITLE
[FIX] BugFix introducido por PR #34

### DIFF
--- a/l10n_ar_perceptions_basic/invoice.py
+++ b/l10n_ar_perceptions_basic/invoice.py
@@ -75,10 +75,10 @@ class perception_tax_line(osv.osv):
         inv = inv_obj.browse(cr, uid, invoice_id)
         company_currency = inv.company_id.currency_id.id
 
-        if inv.type in ('out_invoice', ):
+        if inv.type in ('out_invoice', 'in_invoice'):
             base_amount = cur_obj.compute(cr, uid, inv.currency_id.id, company_currency, base * tax.base_sign, context={'date': inv.date_invoice or time.strftime('%Y-%m-%d')}, round=False)
             tax_amount = cur_obj.compute(cr, uid, inv.currency_id.id, company_currency, amount * tax.tax_sign, context={'date': inv.date_invoice or time.strftime('%Y-%m-%d')}, round=False)
-        else:  # inv is out_refund
+        else:  # inv is Refund
             base_amount = cur_obj.compute(cr, uid, inv.currency_id.id, company_currency, base * tax.ref_base_sign, context={'date': inv.date_invoice or time.strftime('%Y-%m-%d')}, round=False)
             tax_amount = cur_obj.compute(cr, uid, inv.currency_id.id, company_currency, amount * tax.ref_tax_sign, context={'date': inv.date_invoice or time.strftime('%Y-%m-%d')}, round=False)
         return (tax_amount, base_amount)


### PR DESCRIPTION
1. El problema consiste en que para poner el signo positivo a
   base_amount y tax_amount de las percepciones pregunto solo si la factura es out invoice:
   Quedando todas las facturas del tipo in_invoice con el signo negativo.
