### PR TITLE
8.0 fix PR#35

### DIFF
--- a/l10n_ar_perceptions_basic/invoice.py
+++ b/l10n_ar_perceptions_basic/invoice.py
@@ -67,10 +67,10 @@ class perception_tax_line(models.Model):
         currency = invoice.currency_id.with_context(date=invoice.date_invoice or fields.Date.context_today(invoice))
         company_currency = invoice.company_id.currency_id
 
-        if invoice.type in ('out_invoice', ):
+        if invoice.type in ('out_invoice', 'in_invoice'):
             base_amount = currency.compute(base * tax.base_sign, company_currency, round=False)
             tax_amount = currency.compute(amount * tax.tax_sign, company_currency, round=False)
-        else:  # invoice is out_refund
+        else:  # invoice is Refund
             base_amount = currency.compute(base * tax.ref_base_sign, company_currency, round=False)
             tax_amount = currency.compute(amount * tax.ref_tax_sign, company_currency, round=False)
         return (tax_amount, base_amount)


### PR DESCRIPTION
> Replica PR #40 
1. El problema consiste en que para poner el signo positivo a
   base_amount y tax_amount de las percepciones pregunto solo si la factura es out invoice:
   Quedando todas las facturas del tipo in_invoice con el signo negativo.
