### PR TITLE
Make l10n_ar_account_check.view_partner_check_form inherit from account module

### DIFF
--- a/l10n_ar_account_check/partner_view.xml
+++ b/l10n_ar_account_check/partner_view.xml
@@ -18,7 +18,7 @@
         <record id="view_partner_check_form" model="ir.ui.view">
             <field name="name">res.partner.form.check.inherit</field>
             <field name="model">res.partner</field>
-            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="type">form</field>
             <field name="arch" type="xml">
                 <field name="acc_number" position="after">


### PR DESCRIPTION
Hi, 

I've been facing an issue with this view:

When an user that hasn't any of the Account groups assign to him/her wants to access to the partner form view, the view fails to render because it can't find the field 'acc_number' in the parent view. This happens because non-accountant users don't have read perms on the account related views.

So, since ['acc_number' field is added in the account module](https://github.com/ooo/odoo/blob/8.0/addons/account/partner_view.xml#L168), it made sense to me to change the inherit_id of  l10n_ar_account_check.view_partner_check_form view to that in the account module.

Hope this helps!

Thank you for your effort and time!
