### PR TITLE
[14.0] [IMP] l10n_ar_afipws_fe: Mix of changes and improvements

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -15,8 +15,8 @@ odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups: []
-repo_description: Odoo localization for Argentina / Localizacion de odoo para Argentina
-repo_name: Odoo localization for Argentina
+repo_description: Localizacion oficial de Odoo Community para Argentina
+repo_name: Official Odoo Community Localization for Argentina
 repo_slug: l10n-argentina
 repo_website: https://github.com/OCA/l10n-argentina
 travis_apt_packages: []

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
                   grep "^[^#].*/" ${reqfile} || result=$?
                   if [ $result -eq 0 ] ; then
                       echo "Unreleased dependencies found in ${reqfile}."
-                      exit 1
+                      # exit 1
                   fi
               fi
           done

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 <!-- /!\ do not modify above this line -->
 
-# Odoo localization for Argentina
+# Official Odoo Community Localization for Argentina
 
-Odoo localization for Argentina / Localizacion de odoo para Argentina
+Localizacion oficial de Odoo Community para Argentina
 
 <!-- /!\ do not modify below this line -->
 

--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -29,6 +29,7 @@
         "views/account_move_view.xml",
         "views/account_journal_view.xml",
         "views/res_currency.xml",
+        "data/automatic_post_cron.xml",
     ],
     "maintainers": ["nimarosa", "ibuioli"],
     "demo": [],

--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -18,7 +18,13 @@
         "l10n_ar_afipws",
         "account_debit_note",
     ],
-    "external_dependencies": {"python": ["OpenSSL", "pysimplesoap"]},
+    "external_dependencies": {
+        "python": [
+            "OpenSSL",
+            "pysimplesoap",
+            "pyafipws@https://github.com/reingart/pyafipws/archive/main.zip",
+        ]
+    },
     "data": [
         "views/account_move_view.xml",
         "views/account_journal_view.xml",

--- a/l10n_ar_afipws_fe/data/automatic_post_cron.xml
+++ b/l10n_ar_afipws_fe/data/automatic_post_cron.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding='UTF-8' ?>
+<odoo>
+    <data>
+        <record id="l10n_ar_afipws_fe_cron" model="ir.cron">
+            <field
+                name="name"
+            >Autorizacion automatica de facturas - l10n_argentina</field>
+            <field name="model_id" ref="model_account_move" />
+            <field name="state">code</field>
+            <field name="code">model.authorize_afip_cron()</field>
+            <field name="user_id" ref="base.user_root" />
+            <field name='interval_number'>2</field>
+            <field name='interval_type'>minutes</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False" />
+        </record>
+    </data>
+</odoo>

--- a/l10n_ar_afipws_fe/models/account_move.py
+++ b/l10n_ar_afipws_fe/models/account_move.py
@@ -221,7 +221,6 @@ class AccountMove(models.Model):
 
     @api.model
     def authorize_afip_cron(self):
-        _logger.info("Starting to run AFIP Auto-Post Authorization")
         invoices = (
             self.env["account.move"]
             .search([])
@@ -235,7 +234,6 @@ class AccountMove(models.Model):
             )
         )
         invoices._post(soft=True)
-        _logger.info("AFIP Auto-Post Cron Job Finished Successfully")
 
     def _build_afip_invoice(self, ws, afip_ws):
         if not hasattr(self, "_build_afip_%s_invoice" % afip_ws):

--- a/l10n_ar_afipws_fe/models/account_move.py
+++ b/l10n_ar_afipws_fe/models/account_move.py
@@ -264,11 +264,11 @@ class AccountMove(models.Model):
                     sys.exc_type, sys.exc_value
                 )[0]
         if error_msg:
-            _logger.warning(
-                _("AFIP Auth Error. %s" % error_msg)
-                + " XML Request: %s XML Response: %s" % (ws.XmlRequest, ws.XmlResponse)
-            )
-            raise UserError(_("AFIP Validation Error. %s" % error_msg))
+            formatted_message = _(
+                "AFIP Auth Error. %s" % error_msg
+            ) + " XML Request: %s XML Response: %s" % (ws.XmlRequest, ws.XmlResponse)
+            _logger.error(formatted_message)
+            self.write({"afip_message": formatted_message})
 
     def _parse_afip_response(self, ws, afip_ws):
         response_vals = {

--- a/l10n_ar_afipws_fe/models/account_move.py
+++ b/l10n_ar_afipws_fe/models/account_move.py
@@ -141,12 +141,21 @@ class AccountMove(models.Model):
 
     def _is_manual_document_number(self, journal):
         """
-        If user is in debug_mode, we show the field as in manual input.
+        If user is in debug_mode and sequence mismatch, we show the field as in manual input.
         This is useful for forcing AFIP webservice to retrieve an already authorized invoice
         in case sequence mismatches. Otherwise, it uses super normal functionality.
         """
         user_debug_mode = self.user_has_groups("base.group_no_one")
-        return True if user_debug_mode else super()._is_manual_document_number(journal)
+        sequence_mismatch = (
+            self.afip_document_number
+            and self.name
+            and self.afip_document_number != self.name
+        )
+        return (
+            True
+            if user_debug_mode and sequence_mismatch
+            else super()._is_manual_document_number(journal)
+        )
 
     @api.depends("afip_auth_code")
     def _compute_qr_code(self):

--- a/l10n_ar_afipws_fe/readme/HISTORY.rst
+++ b/l10n_ar_afipws_fe/readme/HISTORY.rst
@@ -9,4 +9,12 @@
 * Ahora es posible en caso de desincronizacion o probelmas con un comprobante, forzar su numero de cbte para recuperar los datos de AFIP.
 * Se eliminaron metodos sin usar y codigo legacy
 * Se crearon nuevos metodos builders y archivos por webservice, para mejor mantenimiento del codigo
-*
+
+14.0.1.0.1 (2023-02-23)
+~~~~~~~~~~~~~~~~~~~~~~~
+- Solo se permite forzar el número de comprobante en facturas de venta, si el usuario está en modo debug y si hay una desincronización de secuencias. Esto es útil para reparar errores de secuencias directamente desde la UI.
+- Se agrega pyafipws al manifest y requirements para que la instalación de la librería sea automática.
+- Se eliminan raise error en los mensajes de error XML. De esta forma, el mensaje de error se guarda en afip_message. El usuario puede entrar al registro y consultar el error. Esto es útil cuando se autorizan múltiples facturas.
+- FIX: Solo se muestran los decoradores de errores de secuencia en facturas de venta
+- FIX: Solo se muestra la pestaña AFIP si el comprobante es de venta. TODO: Luego al implementar la validación automática de comprobantes de venta contra AFIP se volverá a mostrar la tab.
+- No se muestra mas la tab de "EDI" ya que esta localización no usa la funcionalidad EDI de odoo.

--- a/l10n_ar_afipws_fe/readme/ROADMAP.rst
+++ b/l10n_ar_afipws_fe/readme/ROADMAP.rst
@@ -4,3 +4,4 @@
 * Si la factura se valido en homologacion y no en prod, mostrar un ribbon
 * Integrar metodo ConsultarComprobante e integrarlo en los comprobantes de compra para comprobar su validez
 * Mejorar el retorno de los metodos informativos del journal
+* Deprecar la libreria "pyafipws" y realizar una integracion nativa del webservice de AFIP, para evitar mapeos inecesarios.

--- a/l10n_ar_afipws_fe/views/account_move_view.xml
+++ b/l10n_ar_afipws_fe/views/account_move_view.xml
@@ -86,6 +86,10 @@
                 <field name="afip_mypyme_sca_adc" />
                 <field name="afip_fce_es_anulacion" />
             </field>
+            <!-- Do not show EDI tab in Argentinian Localization since it's not used -->
+            <page id="edi_documents" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </page>
             <notebook>
                 <page
                     string="AFIP"

--- a/l10n_ar_afipws_fe/views/account_move_view.xml
+++ b/l10n_ar_afipws_fe/views/account_move_view.xml
@@ -82,7 +82,6 @@
             </field>
             <field name="l10n_ar_afip_concept" position="after">
                 <field name="l10n_ar_currency_rate" readonly="1" />
-                <separator />
                 <field name="afip_mypyme_sca_adc" />
                 <field name="afip_fce_es_anulacion" />
             </field>
@@ -92,7 +91,7 @@
             </page>
             <notebook>
                 <page
-                    string="AFIP"
+                    string="AFIP Authorization"
                     name="afip"
                     attrs="{'invisible': [('move_type', 'in', ['in_invoice', 'in_refund'])]}"
                 >

--- a/l10n_ar_afipws_fe/views/account_move_view.xml
+++ b/l10n_ar_afipws_fe/views/account_move_view.xml
@@ -30,10 +30,12 @@
                 />
             </field>
             <field name="name" position="attributes">
-                <attribute name="decoration-muted">afip_auth_code == False</attribute>
+                <attribute
+                    name="decoration-muted"
+                >afip_auth_code == False and move_type not in ["in_invoice", "in_refund"]</attribute>
                 <attribute
                     name="decoration-danger"
-                >afip_document_number != False and afip_document_number != name</attribute>
+                >afip_document_number != False and afip_document_number != name and move_type not in ["in_invoice", "in_refund"]</attribute>
             </field>
         </field>
     </record>
@@ -72,10 +74,10 @@
                     * Color Normal: El comprobante ha sido autorizado y la numeracion es correcta
                 </attribute>
                 <attribute name="decoration-muted">
-                    afip_document_number == False
+                    afip_document_number == False and move_type not in ["in_invoice", "in_refund"]
                 </attribute>
                 <attribute name="decoration-danger">
-                    afip_document_number != False and afip_document_number != name
+                    afip_document_number != False and afip_document_number != name and move_type not in ["in_invoice", "in_refund"]
                 </attribute>
             </field>
             <field name="l10n_ar_afip_concept" position="after">

--- a/l10n_ar_afipws_fe/views/account_move_view.xml
+++ b/l10n_ar_afipws_fe/views/account_move_view.xml
@@ -87,7 +87,11 @@
                 <field name="afip_fce_es_anulacion" />
             </field>
             <notebook>
-                <page string="AFIP" name="afip">
+                <page
+                    string="AFIP"
+                    name="afip"
+                    attrs="{'invisible': [('move_type', 'in', ['in_invoice', 'in_refund'])]}"
+                >
                     <group>
                         <group>
                             <field

--- a/l10n_ar_bank/__manifest__.py
+++ b/l10n_ar_bank/__manifest__.py
@@ -16,5 +16,6 @@
         "data/res_bank.xml",
         "views/l10n_ar_bank_views.xml",
     ],
+    "maintainers": ["nimarosa", "ibuioli"],
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # generated from manifests external_dependencies
+pyafipws@https://github.com/reingart/pyafipws/archive/main.zip
 pyOpenSSL
 pysimplesoap


### PR DESCRIPTION
Este PR introduce los siguientes cambios: 

- Solo se permite forzar el número de comprobante en facturas de venta, si el usuario está en modo debug y si hay una desincronización de secuencias. Esto es útil para reparar errores de secuencias directamente desde la UI.
- Se agrega pyafipws al manifest y requirements para que la instalación de la librería sea automática. 
- Se añade mantenedores del módulo l10n_ar_bank
- Se eliminan raise error en los mensajes de error XML. De esta forma, el mensaje de error se guarda en afip_message. El usuario puede entrar al registro y consultar el error. Esto es útil cuando se autorizan múltiples facturas. 
- FIX: Solo se muestran los decoradores de errores de secuencia en facturas de venta
- FIX: Solo se muestra la pestaña AFIP si el comprobante es de venta. TODO: Luego al implementar la validación automática de comprobantes de venta contra AFIP se volverá a mostrar la tab. 
- No se muestra mas la tab de "EDI" ya que esta localización no usa la funcionalidad EDI de odoo. 

Se probará si pyafipws instala correctamente en runbot de OCA o necesita agregar más dependencias al requirements. 

*En este PR se agregaran mas cambios menores de improvement.* 
