### PR TITLE
[FIX] l10n_ar_afipws_fe: use project name in external_dependencies

### DIFF
--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -22,7 +22,7 @@
         "python": [
             "OpenSSL",
             "pysimplesoap",
-            "pyafipws@https://github.com/reingart/pyafipws/archive/main.zip",
+            "pyafipws",
         ]
     },
     "data": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # generated from manifests external_dependencies
-pyafipws@https://github.com/reingart/pyafipws/archive/main.zip
+pyafipws
 pyOpenSSL
 pysimplesoap

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+pyafipws @ https://github.com/reingart/pyafipws/archive/main.zip


### PR DESCRIPTION
Referencing an URL in external dependencies prevents publishing the module on PyPI.

This causes daily alerts in OCA monitoring and can cause confusion because the latest version is not published on PyPI.