### PR TITLE
[14.0][FIX] l10n_ar_ledger: sanitize partner VAT and fix VAT rate count

### DIFF
--- a/l10n_ar_ledger/models/account_vat_ledger.py
+++ b/l10n_ar_ledger/models/account_vat_ledger.py
@@ -263,21 +263,25 @@ class AccountVatLedger(models.Model):
         return "80"
 
     def get_partner_document_number(self, partner):
-        if partner.l10n_ar_afip_responsibility_type_id.code == "5":
-            number = partner.vat or ""
-            number = re.sub("[^0-9]", "", number)
-        else:
-            number = partner.vat
-        if number is not False:
-            return number.rjust(20, "0")
-        else:
+        """Number of the partner's identification, digits only, right aligned
+        in 20 positions.
+
+        The digital files use a fixed position layout, so any separator kept
+        in the number (``30-71429569-8``) shifts every following field of the
+        line and makes AFIP reject the whole file. The number is therefore
+        sanitized for every responsibility type, not only for Consumidor
+        Final, which is how the partner's VAT is usually stored.
+        """
+        number = re.sub("[^0-9]", "", partner.vat or "")
+        if not number:
             raise ValidationError(
                 _(
-                    "Partner "
-                    + partner.name
-                    + " has not CUIT/CUIL or DNI. Required fro VAT Ledger Book."
+                    "Partner %s has no CUIT/CUIL or DNI. Required for VAT "
+                    "Ledger Book."
                 )
+                % partner.display_name
             )
+        return number.rjust(20, "0")
 
     def get_digital_invoices(self, return_skiped=False):
         self.ensure_one()
@@ -427,17 +431,26 @@ class AccountVatLedger(models.Model):
                 )
 
     def _get_aliquots(self, inv):
+        """Number of VAT rates of the voucher, for field 19 of
+        ``REGDIGITAL_CV_CBTE``.
+
+        Must match the number of records the voucher generates in
+        ``REGDIGITAL_CV_ALICUOTAS``, which comes from ``_get_vat()``: AFIP
+        rejects the pair of files when the declared count differs from the
+        rate records. ``_get_vat()`` keeps only tax groups whose
+        ``l10n_ar_vat_afip_code`` is set and is not ``0``, ``1`` or ``2``, so
+        the same filter is applied here. Taxes with no VAT code at all (an
+        IIBB perception, for instance) were previously counted and made the
+        count diverge.
+        """
         vat_taxes = []
-        vat_exempt_base_amount = 0
         if inv.l10n_latam_document_type_id.code not in ["11", "12", "13"]:
             for invl in inv.invoice_line_ids:
                 for tax in invl.tax_ids:
-                    if tax.tax_group_id.l10n_ar_vat_afip_code not in ["1", "2"]:
+                    vat_afip_code = tax.tax_group_id.l10n_ar_vat_afip_code
+                    if vat_afip_code and vat_afip_code not in ["0", "1", "2"]:
                         if tax.id not in vat_taxes:
                             vat_taxes.append(tax.id)
-                    if self.type == "purchase":
-                        if tax.amount == 0:
-                            vat_exempt_base_amount += invl.price_subtotal
         return len(vat_taxes)
 
     def get_REGDIGITAL_CV_CBTE(self):

--- a/l10n_ar_ledger/tests/__init__.py
+++ b/l10n_ar_ledger/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_vat_ledger

--- a/l10n_ar_ledger/tests/test_account_vat_ledger.py
+++ b/l10n_ar_ledger/tests/test_account_vat_ledger.py
@@ -1,0 +1,99 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ar.tests.common import TestAr
+
+
+@tagged("post_install", "-at_install")
+class TestAccountVatLedger(TestAr):
+    """Regression tests for the digital files field formatting."""
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref="l10n_ar.l10nar_ri_chart_template"):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.ledger = cls.env["account.vat.ledger"].new(
+            {"type": "purchase", "company_id": cls.company_ri.id}
+        )
+
+    def _partner(self, vat, responsibility_xmlid, identification_xmlid):
+        return self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "vat": vat,
+                "l10n_ar_afip_responsibility_type_id": self.env.ref(
+                    responsibility_xmlid
+                ).id,
+                "l10n_latam_identification_type_id": self.env.ref(
+                    identification_xmlid
+                ).id,
+            }
+        )
+
+    def test_document_number_strips_separators_for_any_responsibility(self):
+        """The VAT is stored the way the user types it, with separators.
+
+        The digital files use a fixed position layout: keeping the separators
+        shifts every following field of the line and AFIP rejects the file.
+        Before this fix only Consumidor Final was sanitized.
+        """
+        partner = self._partner("30-71429569-8", "l10n_ar.res_IVARI", "l10n_ar.it_cuit")
+        self.assertEqual(
+            self.ledger.get_partner_document_number(partner),
+            "00000000030714295698",
+        )
+        self.assertEqual(len(self.ledger.get_partner_document_number(partner)), 20)
+
+    def test_document_number_strips_separators_for_consumidor_final(self):
+        """The behaviour that already worked must keep working."""
+        partner = self._partner("20-22222222-3", "l10n_ar.res_CF", "l10n_ar.it_cuit")
+        self.assertEqual(
+            self.ledger.get_partner_document_number(partner),
+            "00000000020222222223",
+        )
+
+    def test_document_number_without_vat_raises(self):
+        """An empty VAT used to produce twenty zeros instead of an error."""
+        partner = self._partner(False, "l10n_ar.res_IVARI", "l10n_ar.it_cuit")
+        with self.assertRaises(ValidationError):
+            self.ledger.get_partner_document_number(partner)
+
+    def test_aliquots_count_matches_the_rate_records(self):
+        """Field 19 of REGDIGITAL_CV_CBTE must match the number of records
+        the same invoice produces in REGDIGITAL_CV_ALICUOTAS.
+
+        Both come from different code paths: the count from `_get_aliquots`
+        and the records from the core `_get_vat()`. A tax without VAT AFIP
+        code (an IIBB perception) used to be counted here but never produced
+        a rate record, so AFIP rejected the pair of files.
+        """
+        invoice = self.init_invoice(
+            "out_invoice",
+            partner=self.res_partner_adhoc,
+            products=self.product_iva_21,
+        )
+        perception = self.env["account.tax"].create(
+            {
+                "name": "Perception IIBB (test)",
+                "amount": 3.0,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "company_id": self.company_ri.id,
+                "tax_group_id": self.tax_perc_iibb.tax_group_id.id,
+            }
+        )
+        invoice.invoice_line_ids[0].tax_ids = [
+            (4, self.tax_21.id),
+            (4, perception.id),
+        ]
+        invoice.action_post()
+
+        self.assertEqual(
+            self.ledger._get_aliquots(invoice),
+            len(invoice._get_vat()),
+            "field 19 must match the number of REGDIGITAL_CV_ALICUOTAS records",
+        )
+        self.assertEqual(self.ledger._get_aliquots(invoice), 1)


### PR DESCRIPTION
Two defects that make AFIP reject the digital files.

The partner VAT was only sanitized for Consumidor Final. For any other
responsibility it went out as typed ("30-71429569-8"), shifting every
following field of the fixed position line.

_get_aliquots counted taxes with no VAT AFIP code (an IIBB perception, for
instance), so field 19 could declare more rates than the number of records
in REGDIGITAL_CV_ALICUOTAS.

Adds the regression tests the module did not have.
