### PR TITLE
[14.0][IMP] Copier update to template v1.44

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,6 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.29
+_commit: v1.44
 _src_path: gh:oca/oca-addons-repo-template
-ci: GitHub
 convert_readme_fragments_to_markdown: false
 enable_checklog_odoo: false
 generate_requirements_txt: true
@@ -16,6 +15,7 @@ odoo_test_flavor: Both
 odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
+postgres_image: ''
 rebel_module_groups: []
 repo_description: Localizacion oficial de Odoo Community para Argentina
 repo_name: Official Odoo Community Localization for Argentina

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-requirements.txt merge=union

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -9,6 +10,10 @@ on:
       - "14.0"
       - "14.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
@@ -16,7 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.8"
+          cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - "14.0"
       - "14.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
@@ -63,6 +67,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.8
   node: "14.13.0"
 repos:
   - repo: local
@@ -38,8 +38,13 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md)$'
+        language: fail
   - repo: https://github.com/oca/maintainer-tools
-    rev: d5fab7ee87fceee858a3d01048c78a548974d935
+    rev: 31bdbd8e4cb94be6534f0e82b1cafb84a455f671
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -104,6 +109,7 @@ repos:
         additional_dependencies:
           - "eslint@7.8.1"
           - "eslint-plugin-jsdoc@"
+          - "globals@"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
@@ -140,7 +146,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_authors=Odoo Community Association (OCA)
@@ -25,19 +28,26 @@ disable=all
 enable=anomalous-backslash-in-string,
     api-one-deprecated,
     api-one-multi-together,
-    assignment-from-none,
-    attribute-deprecated,
     class-camelcase,
-    dangerous-default-value,
     dangerous-view-replace-wo-priority,
-    development-status-allowed,
     duplicate-id-csv,
-    duplicate-key,
     duplicate-xml-fields,
     duplicate-xml-record-id,
     eval-referenced,
-    eval-used,
     incoherent-interpreter-exec-perm,
+    openerp-exception-warning,
+    redundant-modulename-xml,
+    relative-import,
+    rst-syntax-error,
+    wrong-tabs-instead-of-spaces,
+    xml-syntax-error,
+    assignment-from-none,
+    attribute-deprecated,
+    dangerous-default-value,
+    deprecated-module,
+    development-status-allowed,
+    duplicate-key,
+    eval-used,
     license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
@@ -48,40 +58,28 @@ enable=anomalous-backslash-in-string,
     method-inverse,
     method-required-super,
     method-search,
-    openerp-exception-warning,
     pointless-statement,
     pointless-string-statement,
     print-used,
     redundant-keyword-arg,
-    redundant-modulename-xml,
     reimported,
-    relative-import,
     return-in-init,
-    rst-syntax-error,
     sql-injection,
     too-few-format-args,
     translation-field,
     translation-required,
     unreachable,
     use-vim-comment,
-    wrong-tabs-instead-of-spaces,
-    xml-syntax-error,
+    missing-manifest-dependency,
+    too-complex,
     # messages that do not cause the lint step to fail
     consider-merging-classes-inherited,
-    create-user-wo-reset-password,
-    dangerous-filter-wo-user,
     deprecated-module,
-    file-not-used,
     invalid-commit,
-    missing-manifest-dependency,
-    missing-newline-extrafiles,
     missing-readme,
-    no-utf8-coding-comment,
     odoo-addons-relative-import,
-    old-api7-method-defined,
     redefined-builtin,
-    too-complex,
-    unnecessary-utf8-coding-comment
+    manifest-external-assets
 
 
 [REPORTS]

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -3,6 +3,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_authors=Odoo Community Association (OCA)
@@ -17,19 +20,26 @@ disable=all
 enable=anomalous-backslash-in-string,
     api-one-deprecated,
     api-one-multi-together,
-    assignment-from-none,
-    attribute-deprecated,
     class-camelcase,
-    dangerous-default-value,
     dangerous-view-replace-wo-priority,
-    development-status-allowed,
     duplicate-id-csv,
-    duplicate-key,
     duplicate-xml-fields,
     duplicate-xml-record-id,
     eval-referenced,
-    eval-used,
     incoherent-interpreter-exec-perm,
+    openerp-exception-warning,
+    redundant-modulename-xml,
+    relative-import,
+    rst-syntax-error,
+    wrong-tabs-instead-of-spaces,
+    xml-syntax-error,
+    assignment-from-none,
+    attribute-deprecated,
+    dangerous-default-value,
+    deprecated-module,
+    development-status-allowed,
+    duplicate-key,
+    eval-used,
     license-allowed,
     manifest-author-string,
     manifest-deprecated-key,
@@ -40,24 +50,18 @@ enable=anomalous-backslash-in-string,
     method-inverse,
     method-required-super,
     method-search,
-    openerp-exception-warning,
     pointless-statement,
     pointless-string-statement,
     print-used,
     redundant-keyword-arg,
-    redundant-modulename-xml,
     reimported,
-    relative-import,
     return-in-init,
-    rst-syntax-error,
     sql-injection,
     too-few-format-args,
     translation-field,
     translation-required,
     unreachable,
-    use-vim-comment,
-    wrong-tabs-instead-of-spaces,
-    xml-syntax-error
+    use-vim-comment
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+[![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
+
+# Official Odoo Community Localization for Argentina
 [![Runboat](https://img.shields.io/badge/runboat-Try%20me-875A7B.png)](https://runboat.odoo-community.org/builds?repo=OCA/l10n-argentina&target_branch=14.0)
 [![Pre-commit Status](https://github.com/OCA/l10n-argentina/actions/workflows/pre-commit.yml/badge.svg?branch=14.0)](https://github.com/OCA/l10n-argentina/actions/workflows/pre-commit.yml?query=branch%3A14.0)
 [![Build Status](https://github.com/OCA/l10n-argentina/actions/workflows/test.yml/badge.svg?branch=14.0)](https://github.com/OCA/l10n-argentina/actions/workflows/test.yml?query=branch%3A14.0)
@@ -6,8 +9,6 @@
 [![Translation Status](https://translation.odoo-community.org/widgets/l10n-argentina-14-0/-/svg-badge.svg)](https://translation.odoo-community.org/engage/l10n-argentina-14-0/?utm_source=widget)
 
 <!-- /!\ do not modify above this line -->
-
-# Official Odoo Community Localization for Argentina
 
 Localizacion oficial de Odoo Community para Argentina
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "baseBranchPatterns": ["15.0", "14.0", "13.0", "12.0", "11.0"],
+  "enabledManagers": ["copier"]
+}


### PR DESCRIPTION
The repository dotfiles are generated from OCA/oca-addons-repo-template via
copier, and this branch is still pinned to v1.29 while the template is at
v1.44.

The practical consequence is that pre-commit is red on every PR to this
branch, regardless of its content:

    from pkg_resources import resource_string
    ModuleNotFoundError: No module named 'pkg_resources'

setuptools-odoo 3.1.8 imports pkg_resources, which recent setuptools no
longer ships. The template pins 3.3.2 and an explicit interpreter
(python3.8 for this series), which is what other repositories already
running a newer template use: l10n-spain and server-tools are both on
setuptools-odoo 3.3.2 and their pre-commit is green.

Produced with `copier update --vcs-ref v1.44`. Only generated files are
touched, no addon is modified.
